### PR TITLE
General bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+
+#Ignore vscode settings
+.vscode/

--- a/cbinterface.py
+++ b/cbinterface.py
@@ -1,5 +1,4 @@
-#!/data/home/carbonblack/env3/bin/python3
-#/usr/bin/env python3
+#!/usr/bin/env python3
 
 """
 This file is only included in the cbinterface repo 

--- a/cbinterface/__init__.py
+++ b/cbinterface/__init__.py
@@ -399,7 +399,8 @@ if 'https_proxy' in os.environ:
 
 def handle_proxy(profile):
     creds = auth.CredentialStore("response").get_credentials(profile=profile)
-    if 'ignore_system_proxy' in creds:
+    
+    if 'ignore_system_proxy' in creds and 'https_proxy' in os.environ:
         if creds['ignore_system_proxy']:
             if 'https_proxy' in os.environ:
                 del os.environ['https_proxy']

--- a/cbinterface/__init__.py
+++ b/cbinterface/__init__.py
@@ -399,11 +399,10 @@ if 'https_proxy' in os.environ:
 
 def handle_proxy(profile):
     creds = auth.CredentialStore("response").get_credentials(profile=profile)
-    
+
     if 'ignore_system_proxy' in creds and 'https_proxy' in os.environ:
         if creds['ignore_system_proxy']:
-            if 'https_proxy' in os.environ:
-                del os.environ['https_proxy']
+            del os.environ['https_proxy']
         else:
             os.environ['https_proxy'] = HTTPS_PROXY
     return

--- a/cbinterface/__init__.py
+++ b/cbinterface/__init__.py
@@ -1,5 +1,4 @@
-#!/data/home/carbonblack/env3/bin/python3
-#/data/home/smcfeely/dev/env3/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import datetime
@@ -668,6 +667,8 @@ def main():
             credentials = auth.CredentialStore("response").get_credentials(profile=profile)
             if credentials['envtype'].lower() == 'production':
                 profiles.append(profile)
+        
+        
 
 
     # Process Quering #


### PR DESCRIPTION
1) Added .vscode to gitignore so vscode settings are not synced. 
2) Changed shebang line in _init_.py and cbinterface.py to work with the default python path as dictated by the environment. This makes it compatible with virtual environments [which you should use].
3) Moved the os.environ HTTPS_PROXY check to one step earlier, so there is no manipulation of the environment if it was not set in the first place. 
Currently your master banch causes a TypeError exception when it is run and no proxy is set: 
```$: cbinterface -e amnesiac query 'md5:abc123' 
Using amnesiac environment ..
Traceback (most recent call last):
  File "/home/fslds/.virtualenvs/cb-response3/bin/cbinterface", line 11, in <module>
    sys.exit(main())
  File "/home/fslds/.virtualenvs/cb-response3/lib/python3.5/site-packages/cbinterface/__init__.py", line 676, in main
    handle_proxy(profile)
  File "/home/fslds/.virtualenvs/cb-response3/lib/python3.5/site-packages/cbinterface/__init__.py", line 408, in handle_proxy
    os.environ['https_proxy'] = HTTPS_PROXY
  File "/home/fslds/.virtualenvs/cb-response3/lib/python3.5/os.py", line 730, in __setitem__
    value = self.encodevalue(value)
  File "/home/fslds/.virtualenvs/cb-response3/lib/python3.5/os.py", line 798, in encode
    raise TypeError("str expected, not %s" % type(value).__name__)
TypeError: str expected, not NoneType
$: export HTTPS_PROXY                                                             
$:
```