### PR TITLE
Support for multiple envtypes

### DIFF
--- a/cbinterface/__init__.py
+++ b/cbinterface/__init__.py
@@ -501,7 +501,10 @@ def main():
 
     #profiles = auth.CredentialStore("response").get_profiles()
     parser.add_argument('-e', '--environment', choices=auth.CredentialStore("response").get_profiles(),
-                        help='specify an environment you want to work with. Default=All \'production\' environments')
+                        help='specify a specific instance you want to work with. If not defined -t will be used.')
+    parser.add_argument('-t', '--envtypes', type=str, 
+                        help='specify any combination of envtypes. Default=All \'production\' envtypes. Ignored if -e is set.',
+                        default='production')
     #parser.add_argument('--debug', action='store_true', help='print debugging info')
     #parser.add_argument('--warnings', action='store_true',
     #                         help="Warn before printing large executions")
@@ -664,10 +667,13 @@ def main():
         # a little hack for getting our environment type variable defined
         default_profile = auth.default_profile
         default_profile['envtype'] = 'production'
+        envtypes = set(args.envtypes.lower().split(','))
         for profile in auth.CredentialStore("response").get_profiles():
             credentials = auth.CredentialStore("response").get_credentials(profile=profile)
-            if credentials['envtype'].lower() == 'production':
+            envtype = set(credentials['envtype'].lower().split(','))
+            if(envtypes.issubset(envtype)):
                 profiles.append(profile)
+    print(profiles)
 
 
     # Process Quering #

--- a/cbinterface/__init__.py
+++ b/cbinterface/__init__.py
@@ -501,7 +501,7 @@ def main():
 
     #profiles = auth.CredentialStore("response").get_profiles()
     parser.add_argument('-e', '--environment', choices=auth.CredentialStore("response").get_profiles(),
-                        help='specify a specific instance you want to work with. If not defined -t will be used.')
+                        help='specify a specific instance you want to work with. If not defined \'-t production\' will be used implicitly.')
     parser.add_argument('-t', '--envtypes', type=str, 
                         help='specify any combination of envtypes. Default=All \'production\' envtypes. Ignored if -e is set.',
                         default='production')
@@ -673,7 +673,7 @@ def main():
             profile_envtype = set(credentials['envtype'].lower().split(','))
             if(query_envtype.issubset(profile_envtype)):
                 profiles.append(profile)
-                
+
 
     # Process Quering #
     if args.command == 'query':

--- a/cbinterface/__init__.py
+++ b/cbinterface/__init__.py
@@ -667,14 +667,13 @@ def main():
         # a little hack for getting our environment type variable defined
         default_profile = auth.default_profile
         default_profile['envtype'] = 'production'
-        envtypes = set(args.envtypes.lower().split(','))
+        query_envtype = set(args.envtypes.lower().split(','))
         for profile in auth.CredentialStore("response").get_profiles():
             credentials = auth.CredentialStore("response").get_credentials(profile=profile)
-            envtype = set(credentials['envtype'].lower().split(','))
-            if(envtypes.issubset(envtype)):
+            profile_envtype = set(credentials['envtype'].lower().split(','))
+            if(query_envtype.issubset(profile_envtype)):
                 profiles.append(profile)
-    print(profiles)
-
+                
 
     # Process Quering #
     if args.command == 'query':


### PR DESCRIPTION
Hi,

I would like to propose support for different combinations of envtype values. The pull request adds a -t (--envtypes) parameter which let's you specify a comma separated list of envtype values, allowing you to query across combinations of different envtypes. Specifying a specific instance using `-e profilename` is still available of course.

Sample `~/.carbonblack/credentials.response`:
```
[profile1]
url = http://cbresponse1
token = x
envtype = production,financial,EU

[profile2]
url = http://cbresponse2
token = x
envtype = production,financial,US
```

You can now use -t envtype1,envtype2,envtypeX to specify a set of profiles you want to query:

Query all profiles that have a 'production' and 'financial' envtype:
`cbinterface -t production,financial query 'process_name:cmd.exe'`

Query all profiles that have a 'production' and 'EU' envtype:
`cbinterface -t production,EU query 'process_name:cmd.exe'`

Query all 'production' profiles (implicitly uses -t production):
`cbinterface query 'process_name:cmd.exe'`

