### PR TITLE
cbinterface 1.3.0 configurable timezones via config.ini env and -tz arg

### DIFF
--- a/cbinterface/etc/config.ini
+++ b/cbinterface/etc/config.ini
@@ -6,6 +6,13 @@ sensor_work_dir=C:\Windows\CarbonBlack\
 max_recursive_depth=10
 # config path list, later overrides earlier
 config_path_list=etc/config.ini,/etc/carbonblack/cbinterface.ini
+# The default time zone to use for everything -
+#   Must be in the following list: 
+#    from dateutil.zoneinfo import get_zonefile_instance
+#    zonenames = list(get_zonefile_instance().zones) 
+#   ex. 'America/New_York' could be used for eastern time
+#   'GMT' is default as it's the CbR default
+time_zone = GMT 
 
 [memory]
 # procdump included with cbinterface, leave

--- a/cbinterface/modules/process.py
+++ b/cbinterface/modules/process.py
@@ -4,22 +4,10 @@ import os
 import logging
 import datetime
 
-from configparser import ConfigParser
 from cbapi.response import models
 from cbapi.errors import ApiError, ObjectNotFoundError, TimeoutError, MoreThanOneResultError
 
-from .helpers import eastern_time
-
-# Configuration
-HOME_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-CONFIG_PATH = os.path.join(HOME_DIR, 'etc', 'config.ini')
-
-# load the default config
-CONFIG = ConfigParser()
-CONFIG.read(CONFIG_PATH)
-# get the default configuration file paths (allows for users to easily override settings)
-# and re-load the config to account for all config items
-CONFIG.read(CONFIG['DEFAULT']['config_path_list'].split(','))
+from .helpers import CONFIG, as_configured_timezone
 
 
 class ProcessWrapper():
@@ -197,16 +185,16 @@ class ProcessWrapper():
                         signed = b.signed
                         product_name = b.product_name
                         print("%s%s: %s: %s , type:%s , md5:%s, signed:%s, product_name:%s" % ('  ',
-                              eastern_time(fm.timestamp), fm.type, fm.path, fm.filetype,
+                              as_configured_timezone(fm.timestamp), fm.type, fm.path, fm.filetype,
                               fm.md5, signed, product_name))
                     except ObjectNotFoundError:
-                        print("%s%s: %s: %s , type:%s , md5:%s" % ('  ', eastern_time(fm.timestamp),
+                        print("%s%s: %s: %s , type:%s , md5:%s" % ('  ', as_configured_timezone(fm.timestamp),
                               fm.type, fm.path, fm.filetype, fm.md5))
                 elif fm.type != "CreatedFile":
                     if fm.filetype != "Unknown":
-                        print("%s%s: %s: %s , type:%s" % ('  ', eastern_time(fm.timestamp), fm.type, fm.path, fm.filetype))
+                        print("%s%s: %s: %s , type:%s" % ('  ', as_configured_timezone(fm.timestamp), fm.type, fm.path, fm.filetype))
                     else:
-                        print("%s%s: %s: %s" % ('  ', eastern_time(fm.timestamp), fm.type, fm.path))
+                        print("%s%s: %s: %s" % ('  ', as_configured_timezone(fm.timestamp), fm.type, fm.path))
         print()
 
 
@@ -215,7 +203,7 @@ class ProcessWrapper():
         for segment in self.proc.get_segments():
             self.proc.current_segment = segment
             for nc in self.proc.netconns:
-                print("  {}: ({}) local/proxy IP:{}/{} remote IP:{} remote port:{} domain:{}".format(eastern_time(nc.timestamp),
+                print("  {}: ({}) local/proxy IP:{}/{} remote IP:{} remote port:{} domain:{}".format(as_configured_timezone(nc.timestamp),
                                                                                 nc.direction, nc.local_ip, nc.proxy_ip, nc.remote_ip,
                                                                                 nc.remote_port, nc.domain))
         print()
@@ -226,7 +214,7 @@ class ProcessWrapper():
         for segment in self.proc.get_segments():
             self.proc.current_segment = segment
             for rm in self.proc.regmods:
-                print("  {}: {} {}".format(eastern_time(rm.timestamp), rm.type, rm.path))
+                print("  {}: {} {}".format(as_configured_timezone(rm.timestamp), rm.type, rm.path))
         print()
 
 
@@ -236,7 +224,7 @@ class ProcessWrapper():
             self.proc.current_segment = segment
             for modload in self.proc.modloads:
                 sig_status = 'signed' if modload.is_signed else 'unsigned'
-                print("  {}: ({}) {} , md5:{}".format(eastern_time(modload.timestamp),
+                print("  {}: ({}) {} , md5:{}".format(as_configured_timezone(modload.timestamp),
                                                       sig_status, modload.path, modload.md5))
         print()
 
@@ -245,7 +233,7 @@ class ProcessWrapper():
         for segment in self.proc.get_segments():
             self.proc.current_segment = segment
             for unmodload in self.proc.unsigned_modloads:
-                print("  {}: {} , md5:{}".format(eastern_time(unmodload.timestamp),
+                print("  {}: {} , md5:{}".format(as_configured_timezone(unmodload.timestamp),
                                                  unmodload.path, unmodload.md5))
         print()
 
@@ -254,7 +242,7 @@ class ProcessWrapper():
         for segment in self.proc.get_segments():
             self.proc.current_segment = segment
             for cross in self.proc.crossprocs:
-                print("  {} | {} | {} -> {} | {} -> {}".format(eastern_time(cross.timestamp),
+                print("  {} | {} | {} -> {} | {} -> {}".format(as_configured_timezone(cross.timestamp),
                                                                cross.type,
                                                                cross.source_path,
                                                                cross.target_path,
@@ -279,7 +267,7 @@ class ProcessWrapper():
             child_events = children[guid]
             # reverse so they're printed in start/end sequence
             for c in reversed(child_events):
-                print("  {}: {} (PID={}) - {}".format(eastern_time(c.timestamp),
+                print("  {}: {} (PID={}) - {}".format(as_configured_timezone(c.timestamp),
                                                       c.path,
                                                       c.pid,
                                                       c.procguid))
@@ -308,7 +296,7 @@ class ProcessWrapper():
         text += "\n\t-------------------------\n"
         text += "\tProcess Name: {}\n".format(self.proc.process_name)
         text += "\tProcess PID: {}\n".format(self.proc.process_pid)
-        text += "\tProcess Start: {}\n".format(eastern_time(self.proc.start))
+        text += "\tProcess Start: {}\n".format(as_configured_timezone(self.proc.start))
         text += "\tProcess MD5: {}\n".format(self.proc.process_md5)
         text += "\tCommand Line: {}\n".format(self.proc.cmdline)
         text += "\tParent Name: {}\n".format(self.proc.parent_name)

--- a/cbinterface/modules/query.py
+++ b/cbinterface/modules/query.py
@@ -3,7 +3,7 @@ import datetime
 import logging
 from dateutil import tz
 from cbapi.response import *
-from .helpers import eastern_time
+from .helpers import as_configured_timezone
 
 
 ## -- Process querying functions -- ##
@@ -33,7 +33,7 @@ class CBquery():
             processes = self.cb.select(Process).where(query).group_by('id')
             print("\n\tEastern Time\t|\tUsername\t|\tHostname")
             for proc in processes:
-                start_time = str(eastern_time(proc.start))
+                start_time = str(as_configured_timezone(proc.start))
                 start_time = start_time[:start_time.rfind('.')]
                 print("  {}\t    {}\t\t{}".format(start_time, proc.username, proc.hostname))
             print()
@@ -90,7 +90,7 @@ class CBquery():
                 print("\tParent Name: {}".format(proc.parent_name))
                 print("\tHostname: {}".format(proc.hostname))
                 print("\tUsername: {}".format(proc.username))
-                print("\tStart Time: {}".format(eastern_time(proc.start)))
+                print("\tStart Time: {}".format(as_configured_timezone(proc.start)))
                 print("\tGUI Link: {}".format(proc.webui_link))
             print()
         return

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup, find_packages
 from codecs import open
 from os import path
 
-__version__ = "1.2.5"
+__version__ = "1.3.0"
 description = "command line tool for interfacing with multiple carbonblack " \
               "environments to perform analysis and live response functions"
 


### PR DESCRIPTION

Default timezone is same as CbResponse (GMT) and configured in etc/config.ini but can be overridden via /etc/carbonblack/cbinterface.ini or with a CBINTERFACE_TIMEZONE environment variable.

Also, there is a -tz flag to change this on the command line as desired.

The timezones must be in:
```
from dateutil.zoneinfo import get_zonefile_instance
zonenames = list(get_zonefile_instance().zones) 
```